### PR TITLE
Update ghpci.yml

### DIFF
--- a/.github/workflows/ghpci.yml
+++ b/.github/workflows/ghpci.yml
@@ -15,5 +15,5 @@ jobs:
       - run: pip install mkdocs-material
       - run: pip install mkdocs-git-revision-date-plugin
       - run: pip install mkdocs-git-revision-date-localized-plugin
-      - run: mkdocs gh-deploy --force -f config/en/mkdocs.yml
       - run: mkdocs gh-deploy --force -f config/style-guide/mkdocs.yml
+      - run: mkdocs gh-deploy --force -f config/en/mkdocs.yml


### PR DESCRIPTION
Changes the order of gh-deploy commands, so the documentation site is built at the end of the script execution.