### PR TITLE
Update Material for MkDocs build

### DIFF
--- a/config/en/mkdocs.yml
+++ b/config/en/mkdocs.yml
@@ -123,6 +123,7 @@ extra:
       link: https://join.status.im/chat/public/status
 
 # Plugins
+INHERIT: '../../overrides/mkdocs.insiders.yml'
 plugins:
   - search:                                         
       lang: en

--- a/overrides/main.html.bak
+++ b/overrides/main.html.bak
@@ -1,9 +1,5 @@
 {% extends "base.html" %}
 
-{% block copyright %}
-  <a href="https://status.im/get/">Contribute</a>
-{% endblock %}
-
 {% block announce %}
-  <!-- <a href="https://status.im/get/">Check out the new Status release!</a> -->
+  <!-- Announcement -->
 {% endblock %}

--- a/overrides/mkdocs.insiders.yml
+++ b/overrides/mkdocs.insiders.yml
@@ -1,0 +1,3 @@
+# Common Material for MkDocs Insiders configuration file
+plugins:
+  - git-authors

--- a/overrides/mkdocs.yml
+++ b/overrides/mkdocs.yml
@@ -1,1 +1,0 @@
-# Common Material for MkDocs configuration file

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 mkdocs==1.3.0
 mkdocs-material==8.3.8
 mkdocs-material-extensions==1.0.3
+mkdocs-git-authors-plugin==0.6.4
+mkdocs-git-committers-plugin-2==0.4.3
 mkdocs-git-revision-date-plugin==0.3.2
 mkdocs-git-revision-date-localized-plugin==1.0.1
 pyyaml==6.0


### PR DESCRIPTION
- Add Material insiders plugin: git-authors to mkdocs.insiders.yml
- Update requirements.txt to support Material Contributors extension
