### PR TITLE
Create provisional landing page [test]

### DIFF
--- a/config/en/mkdocs.yml
+++ b/config/en/mkdocs.yml
@@ -91,6 +91,7 @@ markdown_extensions:
   - pymdownx.inlinehilite
   - pymdownx.snippets
   - attr_list
+  - md_in_html
   - toc:
       toc_depth: 2
 
@@ -146,6 +147,7 @@ nav:
       - Download Status for mobile: getting-started/download-status-for-mobile.md
   - Using Status:
     - using-status/index.md
+    - using-status/direct-messages.md
   - Communities:
     - status-communities/index.md
   - Wallet:

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -13,7 +13,7 @@ hide:
 
     [:octicons-arrow-right-24: Getting started](#)
 
--   :fontawesome-brands-markdown:{ .lg .middle } __Using Status__
+-   :status-mobile:{ .lg .middle } __Using Status__
 
     ---
 

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -3,14 +3,22 @@ hide:
   - navigation
 ---
 
-# Start
+<div class="grid cards" markdown>
 
-- [Getting started](./getting-started/index.md)
-- [Using Status](./using-status/index.md)
-- [Status Communities](./status-communities/index.md)
-- [Status Wallet](./status-wallet/index.md)
-- [Your profile and preferences](./your-profile-and-preferences/index.md)
-- [Settings](./settings/index.md)
-- [Tutorials](./tutorials/index.md)
+-   :status-travel-and-places:{ .lg .middle } __Getting started__
 
---8<-- "includes/urls-en.txt"
+    ---
+
+    [Getting started desc]
+
+    [:octicons-arrow-right-24: Getting started](#)
+
+-   :fontawesome-brands-markdown:{ .lg .middle } __Using Status__
+
+    ---
+
+    (Using Status desc.)
+
+    [:octicons-arrow-right-24: Using Status](#)
+
+</div>

--- a/docs/en/index.md.ori
+++ b/docs/en/index.md.ori
@@ -1,0 +1,16 @@
+---
+hide:
+  - navigation
+---
+
+# Start
+
+- [Getting started](./getting-started/index.md)
+- [Using Status](./using-status/index.md)
+- [Status Communities](./status-communities/index.md)
+- [Status Wallet](./status-wallet/index.md)
+- [Your profile and preferences](./your-profile-and-preferences/index.md)
+- [Settings](./settings/index.md)
+- [Tutorials](./tutorials/index.md)
+
+--8<-- "includes/urls-en.txt"

--- a/docs/en/using-status/index.md
+++ b/docs/en/using-status/index.md
@@ -4,3 +4,15 @@ hide:
 ---
 
 # Using Status
+
+## Direct messages
+
+## Groups
+
+## Message features and tools
+
+## Share files and conversations
+
+## Status Web3 browser
+
+--8<-- "includes/urls-en.txt"


### PR DESCRIPTION
This is only part of the work required for the provisional landing page.

I'm using this pull request + merge to verify that the Material for MkDocs insiders build is functional. The main index page with the "tiles" configuration in this PR only works when Material is enabled (the configuration works when building the site locally.)

- Draft landing page to test Material insiders' build
- test/provisional to check Material insiders build installation
