### PR TITLE
use requirements.txt in build docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ Consider this information:
 - Issues or pull requests outside of the scope of the Status user documentation project will be discarded with the `wontfix` label.
 - We use the GitHub issue or pull request number to uniquely identify a task.
 
-    > Because pull requests are issues, issue and pull request numbers do not overlap in a repository (see [Issue event types](https://docs.github.com/en/developers/webhooks-and-events/events/issue-event-types) for more information.)
+> Because pull requests are issues, issue and pull request numbers do not overlap in a repository (see [Issue event types](https://docs.github.com/en/developers/webhooks-and-events/events/issue-event-types) for more information.)
 
 ## Support
 
@@ -54,24 +54,17 @@ We use [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/) to bu
 
 > You don't need to install Material for MkDocs to edit Markdown files in the Status Help repo. However, it's a good idea to install Material for MkDocs and make sure your content previews correctly.
 
-1. Install Material for Mkdocs using `pip`:
+Install Python dependencies:
+```sh
+pip install -r requirements.txt
+```
+To preview your changes, go to the root folder in your [Status Help clone](#1-fork-and-clone-this-repository) (by default, this is the `help.status.im` folder in your computer) and run the MkDocs live preview:
+```sh
+mkdocs serve -f config/[language]/mkdocs.yml`
+```
+Where `[language]` corresponds to the language folder name in the Status Help repository.
 
-    `pip install mkdocs-material`
-
-2. Install additional Material for MkDocs `pip` dependencies:
-
-    ```
-    pip install mkdocs-git-revision-date-plugin==0.3.2
-    pip install mkdocs-git-revision-date-localized-plugin==1.0.1
-    ```
-
-3. To preview your changes, go to the root folder in your [Status Help clone](#1-fork-and-clone-this-repository) (by default, this is the `help.status.im` folder in your computer) and run the MkDocs live preview:
-
-    `mkdocs serve -f config/[language]/mkdocs.yml`
-
-    Where `[language]` corresponds to the language folder name in the Status Help repository.
-
-    > To preview your content correctly, remember to run `mkdocs serve` from the root folder in your [Status Help clone](#1-fork-and-clone-this-repository).
+:warning: Calls to `mkdocs` need to be done from the root folder of your [Status Help repo clone](#1-fork-and-clone-this-repository).
 
 ### About Material for MkDocs Insiders
 
@@ -99,19 +92,27 @@ To understand how a repository fork works, see [About forks](https://docs.github
 1. Using the terminal, go to the directory where you want to clone the Status documentation repository.
 1. Fork and clone the repository:
     
-    `gh repo fork 'status-im/help.status.im' --remote --clone=true`
+    ```sh
+    gh repo fork 'status-im/help.status.im' --remote --clone=true
+    ```
     
 ### 2. Create a topic branch and commit changes to your own branch
 
 1. Update your local `develop` branch with the latest changes from `upstream`:
     
-    `git pull upstream develop --rebase --verbose`
+    ```sh
+    git pull upstream develop --rebase --verbose
+    ```
 
-    `git push origin develop`
+    ```sh
+    git push origin develop
+    ```
     
 1. Using the `develop` branch, create a topic branch to include your changes
     
-    `git checkout -b your-topic-branch-name develop`
+    ```sh
+    git checkout -b your-topic-branch-name develop
+    ```
     
     > Use a descriptive name for your feature branch, separating words with dashes. If you know the issue number, include this in the branch name. Examples: `fix-typo-on-creating-status-communities`, `133-wrong-table-values`.
     
@@ -127,11 +128,15 @@ You can test your proposed changes using MkDocs live preview.
 1. Using the terminal, change to the site configuration directory for your language. For example, if you're changing content under the `doc/en` directory, go to the `config/en` in the `help.status.im` repository.
 1. Run the live preview server:
     
-    `mkdocs serve`
+    ```sh
+    mkdocs serve
+    ```
     
 1. The output of this command shows a URL with the IP address and port where the live preview server is running. Example:
     
-    `INFO - [13:48:18] Serving on [http://127.0.0.1:8000/help/en/](http://127.0.0.1:8000/help/en/)`
+    ```
+    INFO - [13:48:18] Serving on [http://127.0.0.1:8000/help/en/](http://127.0.0.1:8000/help/en/)
+    ```
     
 1. Open your browser and enter the URL.
 
@@ -141,25 +146,35 @@ With the Mkdocs live preview server, you can preview your changes as you write y
 
 1. Stage your changes:
     
-    `git add --all`
+    ```sh
+    git add --all
+    ```
     
 1. Commit your changes with a description of what's included:
     
-    `git commit -m "description of your changes"`
+    ```sh
+    git commit -m "description of your changes"
+    ```
     
 1. Set the `upstream` to push your changes:
     
-    `git push --set-upstream origin your-topic-branch-name`
+    ```sh
+    git push --set-upstream origin your-topic-branch-name
+    ```
     
 1. If you need to add more changes, you don't need to set the `upstream` branch again:
     
-    `git push`
+    ```sh
+    git push
+    ```
     
 ### 6. Submit your pull request
 
 1. Create a pull request with your proposed changes:
     
-    `gh pr create --base develop --title "your pull request title"`
+    ```sh
+    gh pr create --base develop --title "your pull request title"
+    ```
     
 1. If prompted for the base repository, select `status-im/help.status.im`:
     


### PR DESCRIPTION
You don't want to maintain package versions in two separate files.

You are asking for divergence between actual dependencies and the install instructions.