### PR TITLE
Fixing the perfect-forward-secrecy URL typo

### DIFF
--- a/docs/en/using-status/about-status-messages.md
+++ b/docs/en/using-status/about-status-messages.md
@@ -48,7 +48,7 @@ The Status app secures your messages the entire time they are in transit using e
 
 When you communicate with someone on the Status app, your messages, attachments, sender metadata, group chats, and group metadata are all end-to-end encrypted.
 
-Status incorporates the [Perfect Forward Secrecy :octicons-tab-external-16:][perfect-foward-secrecy]{:target="_blank"} (PFS) encryption mechanism, ensuring that encryption keys change on every message. If your keys are compromised, only the associated message is compromised. All previous messages remain private.
+Status incorporates the [Perfect Forward Secrecy :octicons-tab-external-16:][perfect-forward-secrecy]{:target="_blank"} (PFS) encryption mechanism, ensuring that encryption keys change on every message. If your keys are compromised, only the associated message is compromised. All previous messages remain private.
 
 !!! info
     Status messaging protects your privacy in one-to-one communications, chat groups, public chats, and Communities.

--- a/includes/urls-en.txt
+++ b/includes/urls-en.txt
@@ -24,6 +24,6 @@
 [register-your-status-ens-name]: /en/your-profile-and-preferences/register-your-status-ens-name
 
 [gnu-privacy-guard]: https://gnupg.org/
-[perfect-foward-secrecy]: https://en.wikipedia.org/wiki/Forward_secrecy
+[perfect-forward-secrecy]: https://en.wikipedia.org/wiki/Forward_secrecy
 [status-web-download]: https://status.im/get
 [waku]: https://waku.org/


### PR DESCRIPTION
The typo is fixed in both the includes/urls-en.txt file and 'About Status messages', the article that mentions forward secrecy.