### PR TITLE
ci: use SSH instead of HTTP for insiders fork

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,7 @@ Install Python dependencies:
 ```sh
 pip install -r requirements.txt
 ```
+:warning: __WARNING:__ You'll need access to the private [mkdocs-material-insiders](https://github.com/status-im/mkdocs-material-insiders) fork.
 
 To preview your changes, go to the root folder in your [Status Help clone](#1-fork-and-clone-this-repository) (by default, this is the `help.status.im` folder in your computer) and run the MkDocs live preview:
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,13 +29,8 @@ pipeline {
   stages {
     stage('Deps') {
       steps {
-        /* Necessary for mkdocs-material-insider package. */
-        withCredentials([
-          string(
-            credentialsId: 'status-im-auto-token',
-            variable: 'GH_TOKEN'
-          )
-        ]) {
+        /* Necessary for private mkdocs-material-insider fork. */
+        sshagent(credentials: ['status-im-auto-ssh']) {
           sh 'pip install --user -r requirements.txt'
         }
       }

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ mkdocs-git-authors-plugin==0.6.4
 mkdocs-git-committers-plugin-2==1.1.1
 mkdocs-git-revision-date-plugin==0.3.2
 mkdocs-git-revision-date-localized-plugin==1.0.1
-git+https://${GH_TOKEN}@github.com/status-im/mkdocs-material-insiders.git
+git+ssh://git@github.com/status-im/mkdocs-material-insiders.git


### PR DESCRIPTION
This way local users don't have to set the `GH_TOKEN` environment vairable if they already have SSH keys set and have access to the repo.