### PR TITLE
Updates October 2022

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .venv
 generated
 .idea/
+.cache/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,7 @@ Install Python dependencies:
 ```sh
 pip install -r requirements.txt
 ```
+:warning: __WARNING:__ You'll need access to the private [mkdocs-material-insiders](https://github.com/status-im/mkdocs-material-insiders) fork.
 
 To preview your changes, go to the root folder in your [Status Help clone](#1-fork-and-clone-this-repository) (by default, this is the `help.status.im` folder in your computer) and run the MkDocs live preview:
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,13 +29,8 @@ pipeline {
   stages {
     stage('Deps') {
       steps {
-        /* Necessary for mkdocs-material-insider package. */
-        withCredentials([
-          string(
-            credentialsId: 'status-im-auto-token',
-            variable: 'GH_TOKEN'
-          )
-        ]) {
+        /* Necessary for private mkdocs-material-insider fork. */
+        sshagent(credentials: ['status-im-auto-ssh']) {
           sh 'pip install --user -r requirements.txt'
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@ pipeline {
         /* Necessary for mkdocs-material-insider package. */
         withCredentials([
           string(
-            credentialsId: 'mkdocs-material-insider-gh-token',
+            credentialsId: 'status-im-auto-token',
             variable: 'GH_TOKEN'
           )
         ]) {

--- a/config/en/mkdocs.yml
+++ b/config/en/mkdocs.yml
@@ -31,7 +31,7 @@ theme:
         primary: white
         accent: teal
         toggle:
-          icon: material/weather-night 
+          icon: material/weather-night
           name: Switch to dark mode
       - media: "(prefers-color-scheme: dark)"
         scheme: slate
@@ -125,10 +125,13 @@ extra:
       link: https://join.status.im/chat/public/status
 
 # Plugins
-INHERIT: '../../overrides/mkdocs.insiders.yml'
 plugins:
-  - search:                                         
+  - search:
       lang: en
+  - git-committers:
+      docs_path: docs/en/
+      repository: status-im/help.status.im
+      branch: master
   - git-revision-date
   - git-revision-date-localized:
       type: date

--- a/config/style-guide/mkdocs.yml
+++ b/config/style-guide/mkdocs.yml
@@ -128,10 +128,13 @@ extra:
       link: https://join.status.im/chat/public/status
 
 # Plugins
-INHERIT: '../../overrides/mkdocs.insiders.yml'
 plugins:
   - search:                                         
       lang: en
+  - git-committers:
+      docs_path: docs/style-guide/
+      repository: status-im/help.status.im
+      branch: master
   - git-revision-date
   - git-revision-date-localized:
       type: date

--- a/docs/style-guide/style-conventions.md
+++ b/docs/style-guide/style-conventions.md
@@ -621,6 +621,7 @@ This picture describes the main user interface areas for Status Web and Status D
 | desktop  | wallet     | :desktop-wallet:     |
 | mobile   | edit       | :mobile-edit:        |
 | mobile   | delete     | :mobile-delete:      |
+| mobile   | send       | :mobile-send:        |
 | web      | members    | :web-members:        |
 
 <br>[:octicons-git-branch-24: Contribute to our docs][contributors-guide]{ .md-button }</br>

--- a/overrides/.icons/mobile/send.svg
+++ b/overrides/.icons/mobile/send.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M12.4596 4.34038L12 3.88076L11.5404 4.34038L5.54038 10.3404L6.45962 11.2596L11.35 6.36924V19.2H12.65V6.36924L17.5404 11.2596L18.4596 10.3404L12.4596 4.34038Z" />
+</svg>

--- a/overrides/mkdocs.insiders.yml
+++ b/overrides/mkdocs.insiders.yml
@@ -1,3 +1,0 @@
-# Common Material for MkDocs Insiders configuration file
-plugins:
-  - git-authors

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ mkdocs-git-authors-plugin==0.6.4
 mkdocs-git-committers-plugin-2==0.4.3
 mkdocs-git-revision-date-plugin==0.3.2
 mkdocs-git-revision-date-localized-plugin==1.0.1
-git+https://${GH_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git
+git+https://${GH_TOKEN}@github.com/status-im/mkdocs-material-insiders.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pyyaml==6.0
 mkdocs==1.3.0
 mkdocs-material-extensions==1.0.3
 mkdocs-git-authors-plugin==0.6.4
-mkdocs-git-committers-plugin-2==0.4.3
+mkdocs-git-committers-plugin-2==1.1.1
 mkdocs-git-revision-date-plugin==0.3.2
 mkdocs-git-revision-date-localized-plugin==1.0.1
 git+https://${GH_TOKEN}@github.com/status-im/mkdocs-material-insiders.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ mkdocs-git-authors-plugin==0.6.4
 mkdocs-git-committers-plugin-2==1.1.1
 mkdocs-git-revision-date-plugin==0.3.2
 mkdocs-git-revision-date-localized-plugin==1.0.1
-git+https://${GH_TOKEN}@github.com/status-im/mkdocs-material-insiders.git
+git+ssh://git@github.com/status-im/mkdocs-material-insiders.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-ghp-import==2.1.0
-pyyaml==6.0
-mkdocs==1.3.0
-mkdocs-material-extensions==1.0.3
-mkdocs-git-authors-plugin==0.6.4
-mkdocs-git-committers-plugin-2==1.1.1
-mkdocs-git-revision-date-plugin==0.3.2
-mkdocs-git-revision-date-localized-plugin==1.0.1
+ghp-import>=2.1.0
+pyyaml>=6.0
+mkdocs>=1.4.0
+mkdocs-material-extensions>=1.0.3
+mkdocs-git-authors-plugin>=0.6.4
+mkdocs-git-committers-plugin-2>=1.1.1
+mkdocs-git-revision-date-plugin>=0.3.2
+mkdocs-git-revision-date-localized-plugin>=1.1.0
 git+ssh://git@github.com/status-im/mkdocs-material-insiders.git


### PR DESCRIPTION
- Added the mobile-send icon
- ci: use mkdocs-material-insders fork repo
- use git-committers instead of git-authors
- ci: use SSH instead of HTTP for insiders fork
- update and loosen pip package requirements
