### PR TITLE
Adding a new extension for custom heading anchors

### DIFF
--- a/config/en/mkdocs.yml
+++ b/config/en/mkdocs.yml
@@ -72,6 +72,7 @@ theme:
 markdown_extensions:
   - meta
   - admonition
+  - attr_list 
   - tables
   - pymdownx.details
   - pymdownx.keys


### PR DESCRIPTION
Hi!

Turns out we need to simply add the [attr_list](https://python-markdown.github.io/extensions/attr_list/) extension to the config file and then include custom IDs wherever we need them in curly brackets:

`## Understand peer-to-peer messaging {: #p2p-messaging }`

This will be rendered as `<h2 id="p2p-messaging">Understand peer-to-peer messaging</h2>`, which can of course then be linked with that new anchor. Tested out and working as expected in my local build.