### PR TITLE
Update Material for MkDocs requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 jinja2>=3.1
-markdown>=3.4
+markdown>=3.2.1
 ghp-import>=2.1.0
 pyyaml>=6.0
 pygments>=2.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,11 @@
+jinja2>=3.0
+markdown>=3.2
 ghp-import>=2.1.0
 pyyaml>=6.0
+pygments>=2.14
 mkdocs>=1.4.2
 mkdocs-material-extensions>=1.1
+pymdown-extension>=9.9
 mkdocs-git-authors-plugin>=0.7.0
 mkdocs-git-committers-plugin-2>=1.1.0
 mkdocs-git-revision-date-plugin>=0.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
-jinja2>=3.0
-markdown>=3.2
+jinja2>=3.1
+markdown>=3.4
 ghp-import>=2.1.0
 pyyaml>=6.0
 pygments>=2.14
 mkdocs>=1.4.2
 mkdocs-material-extensions>=1.1
-pymdown-extension>=9.9
+pymdown-extensions>=9.9
 mkdocs-git-authors-plugin>=0.7.0
 mkdocs-git-committers-plugin-2>=1.1.0
 mkdocs-git-revision-date-plugin>=0.3.2


### PR DESCRIPTION
- Add additional reqs. as per Material for MkDocs insiders repo
- Fix typo pymdown-extension -> pymdown-extensions
- Loosen markdown pip package requirements -- markdown>=3.2.1
