### PR TITLE
295 Leave a channel

### DIFF
--- a/config/en/mkdocs.yml
+++ b/config/en/mkdocs.yml
@@ -166,6 +166,8 @@ nav:
     - status-communities/index.md
     - Status Communities:
       - Join a Status Community: status-communities/join-a-status-community.md
+    - Channels:
+      - Leave a channel: status-communities/leave-a-channel.md
   - Wallet:
     - status-wallet/index.md
   - Your profile:

--- a/docs/en/status-communities/about-losing-access-to-a-community.md
+++ b/docs/en/status-communities/about-losing-access-to-a-community.md
@@ -1,0 +1,15 @@
+---
+id: 301
+revision: 0
+language: en
+hide:
+  - navigation
+---
+
+# About losing access to a community 
+
+!!! note ""
+     We're working on this content.
+
+
+--8<-- "includes/urls-en.txt"

--- a/docs/en/status-communities/channels-your-quick-start-guide.md
+++ b/docs/en/status-communities/channels-your-quick-start-guide.md
@@ -1,0 +1,15 @@
+---
+id: 287
+revision: 0
+language: en
+hide:
+  - navigation
+---
+
+# Channels: your quick start guide
+
+!!! note ""
+     We're working on this content.
+
+
+--8<-- "includes/urls-en.txt"

--- a/docs/en/status-communities/how-to-use-communities-your-quick-start-guide.md
+++ b/docs/en/status-communities/how-to-use-communities-your-quick-start-guide.md
@@ -1,0 +1,15 @@
+---
+id: 110
+revision: 0
+language: en
+hide:
+  - navigation
+---
+
+# How to use Communities: your quick start guide 
+
+!!! note ""
+     We're working on this content.
+
+
+--8<-- "includes/urls-en.txt"

--- a/docs/en/status-communities/index.md
+++ b/docs/en/status-communities/index.md
@@ -9,4 +9,7 @@ hide:
 
 ## Channels
 
+
+- [Leave a channel][leave-a-channel]
+
 --8<-- "includes/urls-en.txt"

--- a/docs/en/status-communities/leave-a-channel.md
+++ b/docs/en/status-communities/leave-a-channel.md
@@ -1,0 +1,11 @@
+---
+id: 295
+revision: 0
+language: en
+hide:
+  - navigation
+---
+
+# Leave a channel
+
+--8<-- "includes/urls-en.txt"

--- a/docs/en/status-communities/leave-a-channel.md
+++ b/docs/en/status-communities/leave-a-channel.md
@@ -8,4 +8,10 @@ hide:
 
 # Leave a channel
 
+There are two kinds of [Status channels](./channels-your-quick-start-guide.md): open and token-gated. Once you join a community, you can access all its open channels. You can access the token-gated channels only by [meeting and maintaining the requirements](./understand-token-requirements-in-channels.md). You cannot leave a channel, but you can lose access to it. The cases are listed below.
+
+* You [leave the community](./how-to-use-communities-your-quick-start-guide.md) 
+* You got [banned or kicked from the community](./about-losing-access-to-a-community.md)
+* Since you no longer [hold the required tokens](./understand-token-requirements-in-channels.md), you cannot access a token-gated channel
+
 --8<-- "includes/urls-en.txt"

--- a/docs/en/status-communities/understand-token-requirements-in-channels.md
+++ b/docs/en/status-communities/understand-token-requirements-in-channels.md
@@ -1,0 +1,15 @@
+---
+id: 290
+revision: 0
+language: en
+hide:
+  - navigation
+---
+
+# Understand token requirements in channels
+
+!!! note ""
+     We're working on this content.
+
+
+--8<-- "includes/urls-en.txt"

--- a/includes/urls-en.txt
+++ b/includes/urls-en.txt
@@ -25,6 +25,7 @@
 [create-a-status-community]: /en/status-communities/create-a-status-community
 [join-a-status-community]: /en/status-communities/join-a-status-community
 [what-is-a-community-channel]: /en/status-communities/what-is-a-community-channel
+[leave-a-channel]: /en/status-communities/leave-a-channel
 
 [about-your-status-display-name]: /en/your-profile-and-preferences/about-your-status-display-name
 [change-your-status-display-name]: /en/your-profile-and-preferences/change-your-status-display-name


### PR DESCRIPTION
Hi @jorge-campo ,

Here is the PR for the article Leave a channel. I'd like to hear your comments.

On **"you leave the community"** I linked to an article called "how-to-use-communities-your-quick-start-guide.md" My first thought was to link to an article named "leave a community" but it did not exist. In the Miro map, I found this link option (quick start guide). Please let me know if creating a place holder for the article "leave a channel" would be more appropriate. In that case, we will need to update the miro map as well as create an issue on Github. 