### PR TITLE
Use a throwaway profile in Status Web

### DIFF
--- a/config/en/mkdocs.yml
+++ b/config/en/mkdocs.yml
@@ -178,6 +178,8 @@ nav:
     - Channels:
       - Join a channel: status-communities/join-a-channel.md
       - About losing access to a channel: status-communities/about-losing-access-to-a-channel.md
+    - Status Web Communities:
+      - Use a throwaway profile in Status Web: status-communities/use-a-throwaway-profile-in-status-web.md
   - Wallet:
     - status-wallet/index.md
   - Your profile:

--- a/docs/en/status-communities/index.md
+++ b/docs/en/status-communities/index.md
@@ -12,4 +12,8 @@ hide:
 - [**Join** a channel][join-a-channel]
 - [About **losing access** to a channel][about-losing-access-to-a-channel]
 
+## Status Web Communities
+
+- [**Use a throwaway profile** in Status Web][use-a-throwaway-profile-in-status-web]
+
 --8<-- "includes/urls-en.txt"

--- a/docs/en/status-communities/understand-throwaway-profiles-in-status-web.md
+++ b/docs/en/status-communities/understand-throwaway-profiles-in-status-web.md
@@ -1,0 +1,16 @@
+---
+id: 216
+revision: 0
+language: en
+hide:
+  - navigation
+---
+
+# Understand throwaway profiles in Status Web
+
+ :octicons-tools-24:
+
+!!! note ""
+     We're working on this content.
+
+--8<-- "includes/urls-en.txt"

--- a/docs/en/status-communities/use-a-throwaway-profile-in-status-web.md
+++ b/docs/en/status-communities/use-a-throwaway-profile-in-status-web.md
@@ -1,0 +1,58 @@
+---
+id: 211
+revision: 0
+hide:
+  - navigation
+---
+
+# Use a throwaway profile in Status Web
+
+!!! note ""
+    Throwaway profiles are only available in Status Web.
+
+Use a [throwaway profile][understand-throwaway-profiles-in-status-web] when you want to participate in a Status Web Community without revealing your identity. A throwaway profile is not linked to any identifiable information or other Status profile you may have.
+
+## Use a throwaway profile
+
+=== "Web"
+
+    1. Using your browser, open the Status Web Community you want to join.
+    1. From the Community sidebar, click **Use throwaway profile**.
+    1. If you see the **Throwaway profile found** pop-up, click **Load throwaway profile** to use the existing profile or click **Skip** to create a new one.
+    1. In the top-right corner, click :status-group-chat: **Members**. Your throwaway profile name appears on the members sidebar.
+
+## Disconnect your throwaway profile
+
+The throwaway profile information remains in your browser cache and persists across browser sessions and computer restarts. To delete this information, disconnect your profile.
+
+=== "Web"
+
+    1. From the right sidebar, click :status-log-out: **logout** next to your profile name.
+    1. On the **Disconnect** pop-up, click **Disconnect**.
+
+!!! tip
+    You can also delete the throwaway profile information by clearing your browser cache.
+
+## Common questions
+
+### What are the three words in my profile?
+
+These words represent your throwaway profile and identity in Status Web. These are randomly generated words.
+
+### Is my throwaway profile really anonymous?
+
+A throwaway profile protects your real identity while using Status Web. However, your internet service provider and browser can still collect identifiable information (like your IP address). Status doesn't collect information about you or your activity.
+
+### Where is the throwaway profile information stored?
+
+Your browser cache stores your throwaway profile. You can delete this information by disconnecting your profile, clearing the cache, or using your browser in incognito or private mode.
+
+### I accidentally deleted my throwaway profile. Can I recover it?
+
+No. Deleting a throwaway profile is an irreversible process.
+
+### Can I use more than one throwaway profile?
+
+There is only one throwaway profile per browser. If you want to use a new throwaway profile, delete the existing one or use a different browser.
+
+--8<-- "includes/urls-en.txt"

--- a/includes/urls-en.txt
+++ b/includes/urls-en.txt
@@ -40,6 +40,8 @@
 [join-a-channel]: /en/status-communities/join-a-channel
 [understand-token-requirements-in-channels]: /en/status-communities/understand-token-requirements-in-channels
 [what-is-a-community-channel]: /en/status-communities/what-is-a-community-channel
+[understand-throwaway-profiles-in-status-web]: /en/status-communities/understand-throwaway-profiles-in-status-web
+[use-a-throwaway-profile-in-status-web]: /en/status-communities/use-a-throwaway-profile-in-status-web
 
 [about-your-status-display-name]: /en/your-profile-and-preferences/about-your-status-display-name
 [change-your-status-display-name]: /en/your-profile-and-preferences/change-your-status-display-name


### PR DESCRIPTION
@shamisem , @Fabiomorais87 -- I include you both as reviewers.

I'm pushing some articles I started to write a few months ago. In the case of Status Web, things are not final until April 2023, so don't put much effort now into these. For example, the option to 'Disconnect your throwaway profile' has been removed, but this is temporary.

> **Note**
> I can't link the project issue for some unknown reason.
