### PR TITLE
Review 'Manage community join requests'

### DIFF
--- a/docs/en/status-communities/index.md
+++ b/docs/en/status-communities/index.md
@@ -33,7 +33,7 @@ Create your community, set up private channels or join others' communities and c
 - [**Restore** your Status Community][restore-your-status-community]
 - [Set up a **private community**][set-up-a-private-community]
 - [**Back up** your community's private key][back-up-your-community-s-private-key]
-- [**Manage** community join requests][manage-community-join-requests]
+- [Manage community **join requests**][manage-community-join-requests]
 
 ## Status Web Communities
 

--- a/docs/en/status-communities/manage-community-join-requests.md
+++ b/docs/en/status-communities/manage-community-join-requests.md
@@ -8,24 +8,32 @@ hide:
 
 # Manage community join requests
 
-As a community owner, you can manually approve requests from people who want to join your community. With this option enabled, you receive a notification whenever someone requests to join your community. This way, you can decide whether to accept, reject or ignore the request.
+!!! note ""
+     Currently, you can only manage community join requests using Status desktop.
+
+You can set up manual or automatic approval join requests for your community. All requests to join your community are automatically approved by default, but you can enable manual approval.
+
+With the manual approval option, you receive a notification whenever someone requests to join your community. This way, you can decide whether to accept, reject or ignore the request.
 
 ## What to expect
 
-- If a community owner rejects a join request, the person who sent the request isn't notified.
-- The community screen is where the user can find out if their request was approved or denied.
+- Users don't receive a notification when a community owner or admin rejects their join request. Users only get a notification when the request to join is accepted.
+- The community screen is where the user can determine the status of their join requests.
+- If your community node is offline (for example, when you turn off your computer or close the Status desktop app), automatic join requests are rejected, and manual join requests time out in seven days. Keep the Status desktop app running as much as possible.
 - In addition to manual approval, you can set up [token requirements][understand-token-requirements-in-communities] to join communities. Manual approval and token requirements work independently.
-- If your community node is offline (for example, when you turn off your computer), automatic join requests stop working. Manual join requests time out in seven days. Keep the Status desktop app running as much as possible.
 
-## Set up community join requests
+!!! note
+    Status Communities take into account token requirements before membership requests.
+
+## Set up the approval request option
 
 === "Desktop"
 
-    1. From the navigation sidebar, click the community you want to set up the manual approval option.
+    1. From the navigation sidebar, click your community.
     1. At the top of the channel sidebar, click your community logo.
     1. Click :desktop-overview: **Overview**.
-    1. At the top of the content area, click **Edit Community**
-    1. Check the **Request to join required** box to enable manual approval.
+    1. At the top of the content area, click **Edit Community**.
+    1. Check or uncheck the **Request to join required** box to enable or disable manual approval.
     1. Click **Save changes**.   
 
 ## Reject or accept community join requests


### PR DESCRIPTION
This is a review of https://github.com/status-im/help.status.im/pull/553.

Thanks, @Fabiomorais87 !

Here are my review comments:

- Your article reads "Manage community join request" but only explains the "manual" part. It doesn't explain the "automatic" part. We should also mention that, without assuming users know an automatic approval option exists.
- "If a community owner rejects a join request, the user who sent the request isn't notified." -> "Users don't receive a notification when a community owner or admin rejects their join request". Write the result of the action first and then the condition for the result.
- I added an admonition at the very beginning to clarify that this option is only available in Status Desktop.
- "... you can manually approve..." -> ... you can manually approve *or reject*..."
- "From the navigation sidebar, click the community you want to set up the manual approval option." -> "From the navigation sidebar, click your community". I can customize this setting only for my community, not for any community in the navigation sidebar.
- "Hover over the user and select Reject or Accept..." -> Positive reactions go first: "Hover over the user and select Accept or Reject..."
- "If your community node is offline (for example, when you turn off your computer), automatic join requests stop working." -> This makes me think automatic join requests are "broken" somehow. I have updated the sentence.
- Article's title in the `index.md` file. You highlighted the word "Manage". "Manage" is a generic word; it appears in many articles. What you should highlight in the `index.md` entry is what's distinctive about the article; the action is taking place of the topic being discussed. In this case, it's the "join request".