### PR TITLE
Grant exclusive access with tokens

### DIFF
--- a/config/en/mkdocs.yml
+++ b/config/en/mkdocs.yml
@@ -255,11 +255,15 @@ nav:
       - Kick or ban someone from your community: status-communities/kick-or-ban-someone-from-your-community.md
       - Delete your Status Community: status-communities/delete-your-status-community.md
     - Use tokens and set community permissions:
+      - Token-based access to communities and channels: status-communities/token-based-access-to-communities-and-channels.md
       - Set up a private community: status-communities/set-up-a-private-community.md
       - Change a private community to public: status-communities/change-a-private-community-to-public.md
       - Permissions by role in Status Communities: status-communities/permissions-by-role-in-status-communities.md
       - Set up your community permissions: status-communities/set-up-your-community-permissions.md
       - Grant exclusive access with custom tokens: status-communities/grant-exclusive-access-with-custom-tokens.md
+      - Permissions by role in Status Communities: status-communities/permissions-by-role-in-status-communities.md
+      - Set up your community permissions: status-communities/set-up-your-community-permissions.md
+      - Grant exclusive access with tokens: status-communities/grant-exclusive-access-with-tokens.md
       - Mint tokens for your community: status-communities/mint-tokens-for-your-community.md
       - How to mint an admin token: status-communities/how-to-mint-an-admin-token.md
       - Import tokens to your community: status-communities/import-tokens-to-your-community.md

--- a/docs/en/getting-started/add-a-contact-in-status.md
+++ b/docs/en/getting-started/add-a-contact-in-status.md
@@ -1,0 +1,45 @@
+---
+id: 382
+revision: 0
+language: en
+hide:
+  - navigation
+---
+
+# Add a contact in Status
+
+To start a chat with someone, you first need to add them to your contacts.
+
+After sending a contact request, wait for the other person to accept it. Once they do that, both you and them can send each other [direct messages][send-direct-messages-to-your-contacts] and invite each other to [group chats][add-members-to-a-group-chat].
+
+If the person you want to chat with doesn't have a Status profile yet, you can [invite them to join Status][invite-friends-to-status].
+
+To add someone to your contact list, you need their [chat key][understand-your-status-keys-and-recovery-phrase], which represents their public Status profile. They can share it with you, so ask them to [Share their Status profile with you][share-your-status-profile]. You can also use their QR code to add them to contacts.
+
+!!! tip
+    To add someone you know from a group chat or community, simply right-click their name and select :desktop-add-user: **Send a contact request**.
+
+## Add a contact
+
+=== "Mobile"
+
+    1. Ask the person you want to add to your contacts to share their profile. 
+    1. From the tab bar, tap :mobile-messages: **Messages**.
+    1. Tap :mobile-add: **Plus** and select :mobile-add-user: **Add a contact**.
+    1. Paste the link to that person's profile into the field or tap :mobile-qr-code: to scan the QR code.
+    1. Tap :mobile-profile: **View profile** > :mobile-profile: **Send contact request**.
+    1. In your introductory message, briefly explain who you are and why you want to add them to your contacts. This is the first message your contact sees from you. Once you're done, tap **Send contact request**.
+
+    !!! tip
+        To see someone's QR code, ask them to go to **Messages** > :mobile-qr-code: **Share**. Follow the steps below to add them to contacts using this code.
+
+
+=== "Desktop"
+
+    1. Ask the person you want to add to your contacts to share their profile. 
+    1. From the navigation sidebar, click :desktop-chat: **Chat**.
+    1. Click :desktop-start-chat: **Start chat**.
+    1. Paste the link to that person's profile into the **To** field.
+    1. In your introductory message, briefly explain who you are and why you want to add them to your contacts. This is the first message your contact sees from you. Once you're done, click **Send contact request**.
+
+--8<-- "includes/urls-en.txt"

--- a/docs/en/status-communities/common-issues-when-the-community-s-control-node-is-offline.md
+++ b/docs/en/status-communities/common-issues-when-the-community-s-control-node-is-offline.md
@@ -1,0 +1,27 @@
+---
+id: 604
+revision: 0
+language: en
+hide:
+  - navigation
+---
+
+# Common issues when the community control node is offline
+
+When you [create a community][create-a-status-community], your computer becomes a [control node][about-the-control-node-in-status-communities]. As the community owner, the control node runs automatically in your Status desktop app if you use the same profile and computer where you set up the community.
+
+!!! note
+    You can [set up a new control node][replace-your-community-s-control-node] if the initial Status desktop fails or becomes inaccessible.
+
+If you don't have the Status desktop app running and connected to the internet, your community keeps working, but your members' experience degrades. Here are some of the problems you and your members may find:
+
+- Members can't access messages over one month because the [Community History Service][about-the-community-history-service] is not running.
+- [Community join requests][manage-community-join-requests] can't be processed and are rejected or ignored.
+- [Banning or kicking out members][kick-or-ban-someone-from-your-community] is delayed until the control node is online.
+- Your community can't verify if members in [token-gated channels][set-up-channel-permissions] still hold the required tokens.
+- Members who could not access a private channel for not [meeting the requirements][understand-token-requirements-in-channels] can't join the channel even if they meet them now.
+
+!!! tip
+    Keep the Status desktop app working as the [community control node][about-the-control-node-in-status-communities] online every day or at least once every six days.
+
+--8<-- "includes/urls-en.txt"

--- a/docs/en/status-communities/grant-exclusive-access-with-tokens.md
+++ b/docs/en/status-communities/grant-exclusive-access-with-tokens.md
@@ -12,7 +12,7 @@ As a community owner in Status, you can use tokens to create different access le
 
 For example, you can use tokens to organize a conference with community access limited to token holders and exclusive channels just for speakers. If you are an artist or content creator, you can set up a community for your fans and give certain fans access to exclusive channels where you release new content.
 
-The options are many, allowing you to create an environment tailored to your community's needs. For more examples of using tokens to provide exclusive access to your community, check out [Token-base access to communities and channels][token-based-access-to-communities-and-channels].
+The options are many, allowing you to create an environment tailored to your community's needs. For more examples of using tokens to provide exclusive access to your community, check out [Token-based access to communities and channels][token-based-access-to-communities-and-channels].
 
 ## Practical example: use a Status Community to organize an event
 

--- a/docs/en/status-communities/grant-exclusive-access-with-tokens.md
+++ b/docs/en/status-communities/grant-exclusive-access-with-tokens.md
@@ -1,0 +1,69 @@
+---
+id: 592
+revision: 0
+language: en
+hide:
+  - navigation
+---
+
+# Grant exclusive access with tokens
+
+As a community owner in Status, you can use tokens to create different access levels within your community. These levels apply to both the community overall and individual channels within it. This approach helps to keep your community engaging and organized.
+
+For example, you can use tokens to organize a conference with community access limited to token holders and exclusive channels just for speakers. If you are an artist or content creator, you can set up a community for your fans and give certain fans access to exclusive channels where you release new content.
+
+The options are many, allowing you to create an environment tailored to your community's needs. For more examples of using tokens to provide exclusive access to your community, check out [Token-base access to communities and channels][token-based-access-to-communities-and-channels].
+
+## Practical example: use a Status Community to organize an event
+
+If you use a Status Community to organize a conference or event, you might want a community open to all interested individuals. Yet, you also need a space just for the speakers.
+
+With tokens, you can limit access to your community only to the individuals invested in the conference topic. Additionally, you can create an exclusive channel within the community, only accessible to the event speakers. This provides a platform for them to discuss and collaborate on the conference preparation.
+
+### Step 1: mint the community tokens
+
+You start minting the community tokens you need to organize the event. In this particular example, you consider two different tokens:
+
+- A general-access token for attendees.
+- A VIP-access token only for speakers.
+
+!!! note
+    Currently, you can only mint collectibles.
+
+- [x] [Mint a new collectible][mint-tokens-for-your-community] to grant general access to the event attendees.
+- [x] Customize the general-access [collectible options][set-up-collectible-options]. For example, you may want to turn on `Unlimited supply` and turn off the `Not transferable (Soulbound)` option.
+- [x] [Mint a collectible][mint-tokens-for-your-community] to grant exclusive access to the event speakers.
+- [x] Configure the VIP-access [collectible options][set-up-collectible-options]. In this case, you may want to turn off `Ulimited supply` and turn on the `Not transferable (Soulbound)` and `Remote self-destruct` options.
+
+!!! note
+    You can't change the collectible description or options after minting.
+
+### Step 2: create the token-based permissions
+
+To create the permissions, check out [Set up your community permissions][set-up-your-community-permissions]. In this example, you create two different permissions using the tokens from the [previous step](#step-1-mint-the-community-tokens):
+
+- Community-level permission to grant general access to the conference attendees.
+- Channel-level permission to grant exclusive channel access to the event speakers.
+
+You may want to configure these permissions as follows:
+
+| Scope           | Applies to             | Variable        | Option                               |
+|:----------------|:-----------------------|:----------------|:-------------------------------------|
+| Community-level | Attendees and speakers | `Who holds`     | Your general-access token            |
+|                 |                        | `Is allowed to` | :desktop-member: Become member       |
+|                 |                        | `In`            | Your community                       |
+| Channel-level   | Speakers only          | `Who holds`     | Your VIP-access token                |
+|                 |                        | `Is allowed to` | :desktop-member: Become member       |
+|                 |                        | `In`            | Your exclusive speakers-only channel |
+
+!!! tip
+    You can also set up exclusive access to communities or channels for holders of a particular ENS domain (for example, alice.acme.eth or bob.acme.eth).
+
+### Step 3: distribute tokens to attendees and speakers
+
+After you [create the permissions](#step-2-create-the-token-based-permissions), you can distribute the tokens via [airdrops][how-to-airdrop-tokens-in-status] to all the conference's participants:
+
+- [x] Airdrop the general-access token to the conference attendees and speakers.
+- [x] Airdrop the VIP-access token to the conference speakers only.
+
+--8<-- "includes/urls-en.txt"

--- a/docs/en/status-communities/index.md
+++ b/docs/en/status-communities/index.md
@@ -55,6 +55,7 @@ Create your community, set up private channels or join others' communities and c
 
 ## Use tokens and set community permissions
 
+- [**Token-based access** to communities and channels][token-based-access-to-communities-and-channels]
 - [Set up a **private community**][set-up-a-private-community]
 - [**Change** a private community to public][change-a-private-community-to-public]
 - [**Permissions by role** in Status Communities][permissions-by-role-in-status-communities]

--- a/docs/en/status-communities/invite-people-to-a-channel.md
+++ b/docs/en/status-communities/invite-people-to-a-channel.md
@@ -18,7 +18,7 @@ Whether you're a comunity owner or a member, you can invite anyone to any channe
 There are three different options you can invite someone to a channel.
 
 | Option | Description | Works with |
-|---------|-------------|------|
+|:---|:---|:---|
 | Invite your Status contacts | You can share the channel with anyone who's on your Status contact list. | Mobile and desktop |
 | Show QR code | Show the channel's QR code to the person you want to invite. | Mobile |
 | Share a link | Share the link via messenger apps or social media. | Mobile and desktop |

--- a/docs/en/status-communities/invite-people-to-a-status-community.md
+++ b/docs/en/status-communities/invite-people-to-a-status-community.md
@@ -17,8 +17,8 @@ Whether you are a community member or not, you can tell people about the communi
 
 There are three approaches to inviting someone.
 
-| Option | Description | Works with |
-|---------|-------------|------|
+| Approach | Description | Works with |
+|:---|:---|:---|
 | Share to Status contacts | Use this option to share the community with people in your Status contact list. | Mobile and desktop |
 | Show QR code | Use this option to show the community QR code to people to scan. | Mobile |
 | Share a link | Use this option to share a link via your other social media or copy it and share it manually. | Mobile and desktop |
@@ -32,7 +32,7 @@ There are three approaches to inviting someone.
     1. In the action sheet, choose an option and proceed as follows:
     
     | Option | Steps |
-    |---------|--------|
+    |:---|:---|
     | Share to Status contacts | 1. Select :mobile-add-user: **Invite people from contacts list**. <br/> 2. Check the boxes next to the contacts you want to share with. <br/> 3. Tap **Invite users**. |
     | Show QR code | 1. Select :moblie-qr-code: **Show QR code**. <br/> 2. Show or send the QR code to people you want to invite. |
     | Share a link | 1. Select :mobile-share: **Share community**. <br/> 2. To share the link via another app on your phone, tap a profile picture or an app icon. To copy the link, tap **Copy**. |
@@ -44,8 +44,8 @@ There are three approaches to inviting someone.
     1. From the navigation sidebar, right click the community logo and then select :desktop-share: **Share**.
     1. Choose the contacts or copy the link and proceed as follows:
     
-    | Approach | Steps |
-    |---------|--------|
+    | Option | Steps |
+    |:---|:---|
     | Share to Status contacts | 1. In the **Invite Contacts** pop-up window, type the names of your contacts in the search bar or check the boxes next to the names. <br/> 2. Click **Next**. <br/> 3. Optionally, type an invitation message. <br/> 4. Click **Send Invites**. | 
     | Share a link | 1. In the **Invite Contacts** pop-up window, click :desktop-copy: **Copy** next to the link. <br/> 2. Switch to the app or platform where you want to share the link and paste it there.
 

--- a/docs/en/status-communities/mint-tokens-for-your-community.md
+++ b/docs/en/status-communities/mint-tokens-for-your-community.md
@@ -13,10 +13,10 @@ hide:
 
 With Status, you can mint custom tokens as a community owner. You have complete control over your token creation and distribution.
 
-Your token's purpose and use are specific to your community. For example, you can reward your entire community or individual members with custom tokens, or offer [exclusive membership to token holders][grant-exclusive-access-with-custom-tokens]. After minting your tokens, you can distribute them to community members and other users of Status via [airdrops][how-to-airdrop-tokens-in-Status].
+Your token's purpose and use are specific to your community. For example, you can reward your entire community or individual members with custom tokens, or offer [exclusive membership to token holders][grant-exclusive-access-with-tokens]. After minting your tokens, you can distribute them to community members and other users of Status via [airdrops][how-to-airdrop-tokens-in-Status].
 
 !!! note
-    Currently, you can only mint collectibles. You will be able to mint assets in a future Status release.
+    Currently, you can only mint collectibles.
 
 When you mint a token, you create a new and unique digital asset in the blockchain network. The blockchain charges you a transaction fee for this process. Fore more details about blockchain fees, check out [Understand network fees][understand-network-fees].
 
@@ -32,18 +32,20 @@ When you mint a token, you create a new and unique digital asset in the blockcha
 
 ## Mint a collectible
 
-1. From the navigation sidebar, click your community.
-1. At the top of the channel sidebar, click your community logo and then, click :desktop-token: **Mint tokens**.
-1. Click **Create new token**.
-1. Customize your collectible by adding its artwork, name and description.
-1. Set up your [collectible options](#set-up-collectible-options).
-1. Click **Preview** to review your new token description and settings and then, click **Mint**.
-1. Review the transaction and fees and click :desktop-password: **Sign transaction**.
+=== "Desktop"
+
+    1. From the navigation sidebar, click your community.
+    1. At the top of the channel sidebar, click your community logo and then, click :desktop-token: **Mint tokens**.
+    1. Click **Create new token**.
+    1. Customize your collectible by adding its artwork, name and description.
+    1. Set up your [collectible options](#set-up-collectible-options).
+    1. Click **Preview** to review your new token description and settings and then, click **Mint**.
+    1. Review the transaction and fees and click :desktop-password: **Sign transaction**.
 
 !!! note
     You can't change the collectible description or options after minting.
 
-## Set up collectible options
+## Set up collectible options {: #set-up-collectible-options }
 
 | Setting | Description |
 |:---|:---|

--- a/docs/en/status-communities/token-based-access-to-communities-and-channels.md
+++ b/docs/en/status-communities/token-based-access-to-communities-and-channels.md
@@ -1,0 +1,16 @@
+---
+id: 653
+revision: 0
+language: en
+hide:
+  - navigation
+---
+
+# Token-based access to communities and channels
+
+ :octicons-tools-24: In progress
+
+!!! note ""
+     We're working on this content.
+
+--8<-- "includes/urls-en.txt"

--- a/includes/urls-en.txt
+++ b/includes/urls-en.txt
@@ -6,6 +6,7 @@
 [your-profile-and-prefences]: /en/your-profile-and-preferences/
 
 [about-the-ethereum-blockchain]: /en/getting-started/about-the-ethereum-blockchain
+[add-a-contact-in-status]: /en/getting-started/add-a-contact-in-status
 [add-a-new-device-to-your-status-profile]: /en/getting-started/add-a-new-device-to-your-status-profile
 [create-or-restore-your-status-profile-using-a-recovery-phrase]: /en/getting-started/create-or-restore-your-status-profile-using-a-recovery-phrase
 [create-or-restore-profile-with-recovery-phrase]: /en/getting-started/create-or-restore-your-status-profile-using-a-recovery-phrase#create-or-restore-profile-with-recovery-phrase
@@ -88,7 +89,7 @@
 [delete-community-permissions]: /en/status-communities/set-up-your-community-permissions#delete-community-permissions
 [delete-your-status-community]: /en/status-communities/delete-your-status-community
 [getting-started-for-community-owners]: /en/status-communities/getting-started-for-community-owners
-[grant-exclusive-access-with-custom-tokens]: /en/status-communities/grant-exclusive-access-with-custom-tokens
+[grant-exclusive-access-with-tokens]: /en/status-communities/grant-exclusive-access-with-tokens
 [how-chs-works]: /en/status-communities/about-the-community-history-service#how-chs-works
 [how-to-airdrop-tokens-in-status]: /en/status-communities/how-to-airdrop-tokens-in-status
 [how-to-mint-an-admin-token]: /en/status-communities/how-to-mint-an-admin-token
@@ -115,8 +116,10 @@
 [set-up-a-private-community]: /en/status-communities/set-up-a-private-community
 [set-up-a-private-channel]: /en/status-communities/set-up-a-private-channel
 [restore-your-status-community]: /en/status-communities/restore-your-status-community
+[set-up-collectible-options]: /en/status-communities/mint-tokens-for-your-community#set-up-collectible-options
 [set-up-your-communitys-approval-options]: /en/status-communities/set-up-your-communitys-approval-options
 [set-up-your-community-permissions]: /en/status-communities/set-up-your-community-permissions
+[token-based-access-to-communities-and-channels]: /en/status-communities/token-based-access-to-communities-and-channels
 [transfer-your-community-s-ownership]: /en/status-communities/transfer-your-community-s-ownership
 [turn-off-the-community-history-service]: /en/status-communities/turn-off-the-community-history-service
 [understand-throwaway-profiles-in-status-web]: /en/status-communities/understand-throwaway-profiles-in-status-web


### PR DESCRIPTION
Using tokens, community owners in Status can configure permissions to restrict access to the community or particular channels within it. 

This article provides a step-by-step example of how to use these token-based permissions to host an event or conference. Other examples will be provided in the upcoming #653. 

These examples' goal is to provide community owners with use cases on how to use token-based permissions in Status Communities.